### PR TITLE
Include occurrenceID in query results from occurrencelist()

### DIFF
--- a/R/zzz.r
+++ b/R/zzz.r
@@ -35,7 +35,7 @@ gbifxmlToDataFrame <- function(doc, format) {
 	if (length(nodes) == 0) 
 		return(data.frame())
 	if(!is.null(format) & format=="darwin"){
-	  varNames <- c("gbifKey", "country", "stateProvince", 
+	  varNames <- c("occurrenceID", "country", "stateProvince", 
 	                "county", "locality", "decimalLatitude", "decimalLongitude", 
 	                "coordinateUncertaintyInMeters", "maximumElevationInMeters", 
 	                "minimumElevationInMeters", "maximumDepthInMeters", 
@@ -43,7 +43,7 @@ gbifxmlToDataFrame <- function(doc, format) {
 	                "catalogNumber", "basisOfRecordString", "collector", 
 	                "earliestDateCollected", "latestDateCollected", "gbifNotes")
 	} else{
-	  varNames <- c("gbifKey", "country", "decimalLatitude", "decimalLongitude",
+	  varNames <- c("occurrenceID", "country", "decimalLatitude", "decimalLongitude",
 	                "catalogNumber", "earliestDateCollected", "latestDateCollected" )
 	}
 	dims <- c(length(nodes), length(varNames))


### PR DESCRIPTION
These two commits modify the function gbifxmlToDataFrame() such that it also extracts the information on a field referred to by the GBIF API as gbifKey. This field is more properly referred to as occurrenceID based on the definition supplied here: https://code.google.com/p/darwincore/wiki/Occurrence#occurrenceID.  The benefit of this field is that you can use this number to look up any record returned from a particular query, for example if the occurrenceID is 145637212 then you can use the following webaddress to retrieve information on that specific record:

http://data.gbif.org/ws/rest/occurrence/get/145637212

Note that in practice the occurrenceID's are supposed to be static; however, it appears that this is not always the case: http://iphylo.blogspot.com/2012/07/dear-gbif-please-stop-changing.html
