### PR TITLE
Get all records when a synonym of correct name was used in query

### DIFF
--- a/R/occ_search.r
+++ b/R/occ_search.r
@@ -248,7 +248,12 @@ occ_search <- function(taxonKey=NULL, scientificName=NULL, country=NULL, publish
 
     # check that wkt is proper format and of 1 of 4 allowed types
     geometry <- check_wkt(geometry)
-
+    # Check synonym if scientificName was given
+    if (!is.null(scientificName)) {
+        namecheck <- name_backbone(scientificName)
+        if (namecheck$synonym)
+            scientificName <- unlist(namecheck[[tolower(namecheck$rank)]])
+    }
     # Make arg list
     args <- rgbif_compact(list(taxonKey=taxonKey, scientificName=scientificName, country=country,
       publishingCountry=publishingCountry, hasCoordinate=hasCoordinate, typeStatus=typeStatus, recordNumber=recordNumber,
@@ -567,3 +572,4 @@ obj_type <- function (x)
 #     }
 #     paste0(tt, collapse = ", ")
 # }
+


### PR DESCRIPTION
If a synonym of correct name was used in the query, only those
records were returned that were stored in the data base with that
synonym. For instance, query of `"Pulsatilla patens"` did not return
the records that were saved with the accepted name `"Anemone patens"`.
All records are returned if you query `"Anemone patens"`, including
those entered as `"Pulsatilla patens"`. Therefore the synonyms must
be replaced with the accepted name.

The same problem persists in `spocc:::foo_gbif()` where the code
takes `usageKey` entry which is guaranteed be wrong  usage with synonym. 
Instead there should be something like:

``` R
tmp <- name_backbone(name = query)
if (tmp$synonym)
   UsageKey <- tmp[[paste0(tolower(tmp$rank), "Key")]]
else
   UsageKey <- tmp$usageKey
```
