### PR TITLE
Implementation internal paging in name_lookup()

### DIFF
--- a/R/name_lookup.r
+++ b/R/name_lookup.r
@@ -8,7 +8,7 @@
 #' # Look up names like mammalia
 #' name_lookup(query='mammalia', limit = 20)
 #'
-#' # Start with a offset
+#' # Start with an offset
 #' name_lookup(query='mammalia', limit=1)
 #' name_lookup(query='mammalia', limit=1, start=2)
 #'

--- a/R/name_lookup.r
+++ b/R/name_lookup.r
@@ -12,7 +12,8 @@
 #' name_lookup(query='mammalia', limit=1)
 #' name_lookup(query='mammalia', limit=1, start=2)
 #'
-#' # large requests (paging is internally implemented). GBIF API maximum: 99999
+#' # large requests (paging is internally implemented).
+#' # hard maximum limit set by GBIF API: 99999
 #' name_lookup(query = "Carnivora", limit = 10000)
 #'
 #' # Get all data and parse it, removing descriptions which can be quite long

--- a/R/name_lookup.r
+++ b/R/name_lookup.r
@@ -8,17 +8,12 @@
 #' # Look up names like mammalia
 #' name_lookup(query='mammalia', limit = 20)
 #'
-#' # Paging
+#' # Start with a offset
 #' name_lookup(query='mammalia', limit=1)
 #' name_lookup(query='mammalia', limit=1, start=2)
 #'
-#' # large requests, use start parameter
-#' first <- name_lookup(query='mammalia', limit=1000)
-#' second <- name_lookup(query='mammalia', limit=1000, start=1000)
-#' tail(first$data)
-#' head(second$data)
-#' first$meta
-#' second$meta
+#' # large requests (paging is internally implemented). GBIF API maximum: 99999
+#' name_lookup(query = "Carnivora", limit = 10000)
 #'
 #' # Get all data and parse it, removing descriptions which can be quite long
 #' out <- name_lookup('Helianthus annuus', rank="species", verbose=TRUE)
@@ -68,8 +63,9 @@
 #' res <- name_lookup(query='canada', hl=TRUE, limit=5)
 #' gbif_names(res)
 #'
-#' # Lookup by datasetKey
-#' name_lookup(datasetKey='3f8a1297-3259-4700-91fc-acc4170b27ce')
+#' # Lookup by datasetKey (set up sufficient high limit, API maximum: 99999)
+#' name_lookup(datasetKey='3f8a1297-3259-4700-91fc-acc4170b27ce',
+#' limit = 50000)
 #'
 #' # Some parameters accept many inputs, treated as OR
 #' name_lookup(rank = c("family", "genus"))
@@ -79,6 +75,8 @@
 #' name_lookup(nameType = c("cultivar", "doubtful"))
 #' name_lookup(datasetKey = c("73605f3a-af85-4ade-bbc5-522bfb90d847",
 #'   "d7c60346-44b6-400d-ba27-8d3fbeffc8a5"))
+#' name_lookup(datasetKey = "289244ee-e1c1-49aa-b2d7-d379391ce265",
+#'   origin = c("SOURCE", "DENORMED_CLASSIFICATION"))
 #'
 #' # Pass on curl options
 #' name_lookup(query='Cnaemidophorus', rank="genus",
@@ -87,7 +85,7 @@
 
 name_lookup <- function(query=NULL, rank=NULL, higherTaxonKey=NULL, status=NULL,
   isExtinct=NULL, habitat=NULL, nameType=NULL, datasetKey=NULL,
-  nomenclaturalStatus=NULL, limit=100, start=NULL, facet=NULL,
+  origin=NULL, nomenclaturalStatus=NULL, limit=100, start=0, facet=NULL,
   facetMincount=NULL, facetMultiselect=NULL, type=NULL, hl=NULL,
   verbose=FALSE, return="all", curlopts = list()) {
 
@@ -106,6 +104,7 @@ name_lookup <- function(query=NULL, rank=NULL, higherTaxonKey=NULL, status=NULL,
   habitat <- as_many_args(habitat)
   nameType <- as_many_args(nameType)
   datasetKey <- as_many_args(datasetKey)
+  origin <- as_many_args(origin)
 
   url <- paste0(gbif_base(), '/species/search')
   args <- rgbif_compact(list(q=query, isExtinct=as_log(isExtinct),
@@ -114,14 +113,52 @@ name_lookup <- function(query=NULL, rank=NULL, higherTaxonKey=NULL, status=NULL,
             facetMultiselect=as_log(facetMultiselect), hl=as_log(hl),
             type=type))
   args <- c(args, facetbyname, rank, higherTaxonKey, status,
-            habitat, nameType, datasetKey)
-  tt <- gbif_GET(url, args, FALSE, curlopts)
+            habitat, nameType, datasetKey, origin)
+
+  # paging implementation
+  if (limit > 1000) {
+    iter <- 0
+    sumreturned <- 0
+    numreturned <- 0
+    outout <- list()
+    while (sumreturned < limit) {
+      iter <- iter + 1
+      tt <- gbif_GET(url, args, FALSE, curlopts)
+      # if no results, assign numreturned var with 0
+      if (identical(tt$results, list())) {
+        numreturned <- 0}
+      else {
+        numreturned <- length(tt$results)}
+      sumreturned <- sumreturned + numreturned
+      # if less results than maximum
+      if ((numreturned > 0) && (numreturned < 1000)) {
+        # update limit for metadata before exiting
+        limit <- numreturned
+        args$limit <- limit
+      }
+      if (sumreturned < limit) {
+        # update args for next query
+        args$offset <- args$offset + numreturned
+        args$limit <- limit - sumreturned
+      }
+      outout[[iter]] <- tt
+    }
+    out <- list()
+    out$results <- do.call(c, lapply(outout, "[[", "results"))
+    out$offset <- args$offset
+    out$limit <- args$limit
+    out$count <- outout[[1]]$count
+    out$endOfRecords <- outout[[iter]]$endOfRecords
+  } else {
+    # retrieve data in a single query
+    out <- gbif_GET(url, args, FALSE, curlopts)
+  }
 
   # metadata
-  meta <- tt[c('offset', 'limit', 'endOfRecords', 'count')]
+  meta <- out[c('offset', 'limit', 'endOfRecords', 'count')]
 
   # facets
-  facets <- tt$facets
+  facets <- out$facets
   if (!length(facets) == 0) {
     facetsdat <- lapply(facets, function(x)
       do.call(rbind, lapply(x$counts, data.frame, stringsAsFactors = FALSE)))
@@ -134,28 +171,28 @@ name_lookup <- function(query=NULL, rank=NULL, higherTaxonKey=NULL, status=NULL,
   if (!verbose) {
     data <- tibble::as_data_frame(data.table::setDF(
       data.table::rbindlist(
-        lapply(tt$results, namelkupcleaner),
+        lapply(out$results, namelkupcleaner),
         use.names = TRUE, fill = TRUE)))
     if (limit > 0) data <- movecols(data, c('key', 'scientificName'))
   } else {
-    data <- tt$results
+    data <- out$results
   }
 
   # hierarchies
-  hierdat <- lapply(tt$results, function(x){
+  hierdat <- lapply(out$results, function(x){
     tmp <- x[ names(x) %in% "higherClassificationMap" ]
     tmpdf <- data.frame(rankkey = names(rgbif_compact(tmp[[1]])),
                         name = unlist(unname(rgbif_compact(tmp[[1]]))),
                         stringsAsFactors = FALSE)
     if (NROW(tmpdf) == 0) NULL else tmpdf
   })
-  names(hierdat) <- vapply(tt$results, "[[", numeric(1), "key")
+  names(hierdat) <- vapply(out$results, "[[", numeric(1), "key")
 
   # vernacular names
-  vernames <- lapply(tt$results, function(x){
+  vernames <- lapply(out$results, function(x){
     rbind_fill(lapply(x$vernacularNames, data.frame))
   })
-  names(vernames) <- vapply(tt$results, "[[", numeric(1), "key")
+  names(vernames) <- vapply(out$results, "[[", numeric(1), "key")
 
   # select output
   return <- match.arg(return, c('meta', 'data', 'facets', 'hierarchy',

--- a/man-roxygen/namelkup.r
+++ b/man-roxygen/namelkup.r
@@ -95,8 +95,8 @@
 #' is done. And therefore, all parameters with facet in their name are
 #' ignored (facetOnly, facetMincount, facetMultiselect).
 #'
-#' @section Repeat parmeter inputs:
-#' Some parameters can tak emany inputs, and treated as 'OR' (e.g., a or b or
+#' @section Repeat parameter inputs:
+#' Some parameters can take many inputs, and treated as 'OR' (e.g., a or b or
 #' c). The following take many inputs:
 #' \itemize{
 #'  \item \strong{rank}

--- a/man-roxygen/namelkup.r
+++ b/man-roxygen/namelkup.r
@@ -68,8 +68,8 @@
 #' additional full text field is searched which includes information from
 #' metadata documents, but the text of this field is not returned in the
 #' response.
-#' @param limit Number of records to return. Maximum: 1000.
-#' @param start Record number to start at.
+#' @param limit Number of records to return. Maximum provided by API: 99999.
+#' @param start Record number to start at. Default: 0.
 #' @param verbose (logical) If \code{TRUE}, all data is returned as a list for each
 #' element. If \code{FALSE} (default) a subset of the data that is thought to be most
 #' essential is organized into a data.frame.

--- a/man-roxygen/namelkup.r
+++ b/man-roxygen/namelkup.r
@@ -68,7 +68,8 @@
 #' additional full text field is searched which includes information from
 #' metadata documents, but the text of this field is not returned in the
 #' response.
-#' @param limit Number of records to return. Maximum provided by API: 99999.
+#' @param limit Number of records to return.
+#' Hard maximum limit set by GBIF API: 99999.
 #' @param start Record number to start at. Default: 0.
 #' @param verbose (logical) If \code{TRUE}, all data is returned as a list for each
 #' element. If \code{FALSE} (default) a subset of the data that is thought to be most

--- a/man/name_lookup.Rd
+++ b/man/name_lookup.Rd
@@ -6,8 +6,8 @@
 \usage{
 name_lookup(query = NULL, rank = NULL, higherTaxonKey = NULL,
   status = NULL, isExtinct = NULL, habitat = NULL, nameType = NULL,
-  datasetKey = NULL, nomenclaturalStatus = NULL, limit = 100,
-  start = NULL, facet = NULL, facetMincount = NULL,
+  datasetKey = NULL, origin = NULL, nomenclaturalStatus = NULL,
+  limit = 100, start = 0, facet = NULL, facetMincount = NULL,
   facetMultiselect = NULL, type = NULL, hl = NULL, verbose = FALSE,
   return = "all", curlopts = list())
 }
@@ -68,9 +68,9 @@ or terrestrial}
 \item{nomenclaturalStatus}{Not yet implemented, but will eventually allow
 for filtering by a nomenclatural status enum}
 
-\item{limit}{Number of records to return. Maximum: 1000.}
+\item{limit}{Number of records to return. Maximum provided by API: 99999.}
 
-\item{start}{Record number to start at.}
+\item{start}{Record number to start at. Default: 0.}
 
 \item{facet}{A vector/list of facet names used to retrieve the 100 most
 frequent values for a field. Allowed facets are: datasetKey, higherTaxonKey,
@@ -132,9 +132,9 @@ Faceting: If \code{facet=FALSE} or left to the default (NULL), no faceting
 is done. And therefore, all parameters with facet in their name are
 ignored (facetOnly, facetMincount, facetMultiselect).
 }
-\section{Repeat parmeter inputs}{
+\section{Repeat parameter inputs}{
 
-Some parameters can tak emany inputs, and treated as 'OR' (e.g., a or b or
+Some parameters can take many inputs, and treated as 'OR' (e.g., a or b or
 c). The following take many inputs:
 \itemize{
  \item \strong{rank}
@@ -153,17 +153,12 @@ see also \code{\link{many-values}}
 # Look up names like mammalia
 name_lookup(query='mammalia', limit = 20)
 
-# Paging
+# Start with a offset
 name_lookup(query='mammalia', limit=1)
 name_lookup(query='mammalia', limit=1, start=2)
 
-# large requests, use start parameter
-first <- name_lookup(query='mammalia', limit=1000)
-second <- name_lookup(query='mammalia', limit=1000, start=1000)
-tail(first$data)
-head(second$data)
-first$meta
-second$meta
+# large requests (paging is internally implemented). GBIF API maximum: 99999
+name_lookup(query = "Carnivora", limit = 10000)
 
 # Get all data and parse it, removing descriptions which can be quite long
 out <- name_lookup('Helianthus annuus', rank="species", verbose=TRUE)
@@ -213,8 +208,9 @@ name_lookup(query='canada', hl=TRUE, limit=45, return='data')
 res <- name_lookup(query='canada', hl=TRUE, limit=5)
 gbif_names(res)
 
-# Lookup by datasetKey
-name_lookup(datasetKey='3f8a1297-3259-4700-91fc-acc4170b27ce')
+# Lookup by datasetKey (set up sufficient high limit, API maximum: 99999)
+name_lookup(datasetKey='3f8a1297-3259-4700-91fc-acc4170b27ce',
+limit = 50000)
 
 # Some parameters accept many inputs, treated as OR
 name_lookup(rank = c("family", "genus"))
@@ -224,6 +220,8 @@ name_lookup(habitat = c("marine", "terrestrial"))
 name_lookup(nameType = c("cultivar", "doubtful"))
 name_lookup(datasetKey = c("73605f3a-af85-4ade-bbc5-522bfb90d847",
   "d7c60346-44b6-400d-ba27-8d3fbeffc8a5"))
+name_lookup(datasetKey = "289244ee-e1c1-49aa-b2d7-d379391ce265",
+  origin = c("SOURCE", "DENORMED_CLASSIFICATION"))
 
 # Pass on curl options
 name_lookup(query='Cnaemidophorus', rank="genus",

--- a/man/name_usage.Rd
+++ b/man/name_usage.Rd
@@ -20,7 +20,7 @@ See Description below.}
 
 \item{language}{(character) Language, default is english}
 
-\item{datasetKey}{(character) Filters by the dataset's key (a uuid). must
+\item{datasetKey}{(character) Filters by the dataset's key (a uuid). must 
 be length=1}
 
 \item{uuid}{(character) A datset key}
@@ -37,7 +37,7 @@ SUBPHYLUM, SUBSECTION, SUBSERIES, SUBSPECIES, SUBTRIBE, SUBVARIETY,
 SUPERCLASS, SUPERFAMILY, SUPERORDER, SUPERPHYLUM, SUPRAGENERIC_NAME,
 TRIBE, UNRANKED, VARIETY}
 
-\item{shortname}{(character) A short name for a dataset - it may
+\item{shortname}{(character) A short name for a dataset - it may 
 not do anything}
 
 \item{start}{Record number to start at. Default: 0.}

--- a/tests/testthat/test-name_lookup.r
+++ b/tests/testthat/test-name_lookup.r
@@ -103,9 +103,9 @@ test_that("paging: name_usage returns all records from dataset: limit > n_record
   # 1051 total records (any origin, i.e. SOURCE and DENORMED_CLASSIFICATION)
   cc <- name_lookup(datasetKey = "a5224e5b-6379-4d33-a29d-14b56015893d",
                     limit = 5000)
-  expect_equal(cc$meta$offset, 1000)
-  expect_equal(cc$meta$limit, 51)
+  expect_gte(cc$meta$offset, 1000)
+  expect_gte(cc$meta$limit, 51)
   expect_equal(cc$meta$endOfRecords, TRUE)
-  expect_equal(cc$meta$count, 1051)
-  expect_equal(nrow(cc$data), 1051)
+  expect_gte(cc$meta$count, 1051)
+  expect_gte(nrow(cc$data), 1051)
 })

--- a/tests/testthat/test-name_lookup.r
+++ b/tests/testthat/test-name_lookup.r
@@ -62,3 +62,41 @@ test_that("works with parameters that allow many inputs", {
   expect_true(all(
     unique(tolower(aa$data$nameType)) %in% c("cultivar", "doubtful")))
 })
+
+#paging (limit higher than 1000 records; maximum API: 99999)
+test_that("paging: name_usage returns as many records as asked, limit > 1000", {
+    skip_on_cran()
+  #https://www.gbif.org/dataset/a5224e5b-6379-4d33-a29d-14b56015893d
+  # 1051 total records (any origin, i.e. SOURCE and DENORMED_CLASSIFICATION)
+  aa <- name_lookup(datasetKey = "a5224e5b-6379-4d33-a29d-14b56015893d",
+                                      limit = 1001)
+                     expect_equal(aa$meta$offset, 1000)
+                     expect_equal(aa$meta$limit, 1)
+                     expect_equal(nrow(aa$data), 1001)
+})
+
+test_that("paging: class data and meta not modified by paging", {
+  skip_on_cran()
+
+  bb1 <- name_lookup(datasetKey = "a5224e5b-6379-4d33-a29d-14b56015893d",
+                   limit = 1)
+  bb2 <- name_lookup(datasetKey = "a5224e5b-6379-4d33-a29d-14b56015893d",
+                    limit = 1002)
+  expect_true(all(class(bb1) == class(bb2)))
+  expect_true(all(class(bb1$meta) == class(bb2$meta)))
+  expect_true(all(class(bb1$data) == class(bb2$data)))
+})
+
+test_that("paging: name_usage returns all records from dataset: limit > n_records", {
+  skip_on_cran()
+
+  #https://www.gbif.org/dataset/a5224e5b-6379-4d33-a29d-14b56015893d
+  # 1051 total records (any origin, i.e. SOURCE and DENORMED_CLASSIFICATION)
+  cc <- name_lookup(datasetKey = "a5224e5b-6379-4d33-a29d-14b56015893d",
+                    limit = 5000)
+  expect_equal(cc$meta$offset, 1000)
+  expect_equal(cc$meta$limit, 51)
+  expect_equal(cc$meta$endOfRecords, TRUE)
+  expect_equal(cc$meta$count, 1051)
+  expect_equal(nrow(cc$data), 1051)
+})


### PR DESCRIPTION
## Description
I implemented internal paging in `name_lookup()`. I did it following the same idea as in `name_usage.r`.
I tried to add specific tests too in `./tests/testthat/test-name_lookup.r`. I tried to optimize them as much as possible by using the same checklist and querying just-enough number of taxa. I hope they run in a reasonable time.

### Question
Up to now we use 1000 as limit for triggering internal paging (see [here](https://github.com/ropensci/rgbif/blob/master/R/name_usage.r#L106), and [here](https://github.com/damianooldoni/rgbif/blob/paging_name_lookup/R/name_lookup.r#L120)), which is the maximum limit possible. In `occ_data.r` it is 300. Considering we are going for internal paging over more and more functions, a colleague suggested to save this number in a variable, visible to all functions in the package (in `zzz.r`?). I find it an interesting idea. I would like to know your idea about it.

## Related Issue
Inspired by internal paging implementation in `name_usage()` (see #291) and considering the fact that we need to retrieve all taxa from several checklists as straightforward as possible, we thought it would be useful to implement paging in `name_lookup()` as well.

## Example
extracted from `test-name_lookup.r`:
```r
aa <- name_lookup(datasetKey = "a5224e5b-6379-4d33-a29d-14b56015893d",
                                      limit = 1001)
                     expect_equal(aa$meta$offset, 1000)
                     expect_equal(aa$meta$limit, 1)
                     expect_equal(nrow(aa$data), 1001)
```
