### PR TITLE
Correct typo in URL

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -21,5 +21,5 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 opening an issue or contacting one or more of the project maintainers.
 
 This Code of Conduct is adapted from the Contributor Covenant 
-(http:contributor-covenant.org), version 1.0.0, available at 
+(http://contributor-covenant.org), version 1.0.0, available at 
 http://contributor-covenant.org/version/1/0/0/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Noticed a typo in the URL of the code of conduct. I've seen it elsewhere to, must be an error in the template.
