### PR TITLE
Solve #370

### DIFF
--- a/R/print_gbif.R
+++ b/R/print_gbif.R
@@ -102,21 +102,23 @@ pastemax <- function(z, type='counts', n=10){
 
 #' @export
 print.gbif_data <- function(x, ..., n = 10) {
-  if (attr(x, "type") == "single") {
-    cat(rgbif_wrap(sprintf("Records found [%s]", x$meta$count)), "\n")
-    cat(rgbif_wrap(sprintf("Records returned [%s]", NROW(x$data))), "\n")
-    cat(rgbif_wrap(sprintf("Args [%s]", pasteargs(x))), "\n")
-    if (inherits(x$data, "data.frame")) print(x$data) else cat(x$data)
-  } else if (attr(x, "type") == "many") {
-    cat(rgbif_wrap(sprintf("Occ. found [%s]", pastemax(x))), "\n")
-    cat(rgbif_wrap(sprintf("Occ. returned [%s]", pastemax(x, "returned"))), "\n")
-    cat(rgbif_wrap(sprintf("Args [%s]", pasteargs(x))), "\n")
-    cat(sprintf("%s requests; First 10 rows of data from %s\n\n", length(x), substring(names(x)[1], 1, 50)))
-    if (inherits(x[[1]]$data, "data.frame")) print(x[[1]]$data) else cat(x[[1]]$data)
+  if ("type" %in% names(attributes(x))) {
+    if (attr(x, "type") == "single") {
+      cat(rgbif_wrap(sprintf("Records found [%s]", x$meta$count)), "\n")
+      cat(rgbif_wrap(sprintf("Records returned [%s]", NROW(x$data))), "\n")
+      cat(rgbif_wrap(sprintf("Args [%s]", pasteargs(x))), "\n")
+      if (inherits(x$data, "data.frame")) print(x$data) else cat(x$data)
+    } else if (attr(x, "type") == "many") {
+      cat(rgbif_wrap(sprintf("Occ. found [%s]", pastemax(x))), "\n")
+      cat(rgbif_wrap(sprintf("Occ. returned [%s]", pastemax(x, "returned"))), "\n")
+      cat(rgbif_wrap(sprintf("Args [%s]", pasteargs(x))), "\n")
+      cat(sprintf("%s requests; First 10 rows of data from %s\n\n", length(x), substring(names(x)[1], 1, 50)))
+      if (inherits(x[[1]]$data, "data.frame")) print(x[[1]]$data) else cat(x[[1]]$data)
+    }
   } else {
     if (inherits(x, "gbif_data")) x <- unclass(x)
     attr(x, "type") <- NULL
     attr(x, "return") <- NULL
-    print(x)
+    print(tibble::as_tibble(x))
   }
 }

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -10,13 +10,13 @@
 |collate  |English_United States.1252   |
 |ctype    |English_United States.1252   |
 |tz       |Europe/Paris                 |
-|date     |2019-08-05                   |
+|date     |2019-08-07                   |
 
 # Dependencies
 
 |package      |old      |new        |<U+0394>  |
 |:------------|:--------|:----------|:--|
-|rgbif        |1.3.0    |1.3.0.9134 |*  |
+|rgbif        |1.3.0    |1.3.3.9110 |*  |
 |askpass      |NA       |1.1        |*  |
 |assertthat   |0.2.1    |0.2.1      |   |
 |backports    |NA       |1.1.4      |*  |
@@ -35,7 +35,7 @@
 |glue         |NA       |1.3.1      |*  |
 |gtable       |0.3.0    |0.3.0      |   |
 |httpcode     |0.2.0    |0.2.0      |   |
-|httr         |NA       |1.4.0      |*  |
+|httr         |NA       |1.4.1      |*  |
 |jsonlite     |1.6      |1.6        |   |
 |labeling     |0.3      |0.3        |   |
 |lazyeval     |0.2.2    |0.2.2      |   |


### PR DESCRIPTION
## Description

This PR solves a bug occurring while printing inherited objects of class `gbif_data`, e.g. the output of function occ_issues applied to objects of class `gbif_data`.
The bug is due to the fact that the output of `occ_issues` inherits class `gbif_data` but has no attribute `type` as `occ_issues` doesn't send any query to gbif API. By consequence, checking whether type is equal to `many` or `single` arise an error.

## Related Issue
This PR should fix #370.

## Example
See example in issue.