### PR TITLE
add lit_search to pkgdown ref config

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -71,6 +71,7 @@ reference:
       - gbif_issues
       - gbif_issues_lookup
       - occ_issues
+      - lit_search
   - title: "Pretty html reports"
     contents:
       - gbif_names


### PR DESCRIPTION
We see

```r
> pkgdown::check_pkgdown()
Error in `check_missing_topics()` at pkgdown/R/build-reference-index.R:16:2:
! All topics must be included in reference index
✖ Missing topics: lit_search
ℹ Either add to _pkgdown.yml or use @keywords internal
```

on https://ropensci.r-universe.dev/builds

I didn't know where to put the function, you'll know best. :grin: 