### PR TITLE
setting quote as default for occ_download_import

### DIFF
--- a/R/occ_download_import.R
+++ b/R/occ_download_import.R
@@ -86,7 +86,7 @@ occ_download_import <- function(x=NULL, key=NULL, path=".", fill = FALSE,
   targetpath <- file.path(tmpdir, tpath)
   if (!file.exists(tmpdir)) stop("appropriate file not found", call. = FALSE)
   df <- data.table::fread(targetpath, data.table = FALSE, fill = fill, 
-    encoding = encoding, ...)
+    encoding = encoding, quote="", ...)
   if(!is.null(df$countryCode)) df$countryCode[is.na(df$countryCode)] <- "NA"
   structure(tibble::as_tibble(df), type = "single")
 }


### PR DESCRIPTION
https://github.com/ropensci/rgbif/issues/662

fixes this warning
```
Found and resolved improper quoting out-of-sample. First healed line 488899: <<1999465326 6ac3f774-d9fb-4796-b3e9-92bf6c81c084 Animalia Arthropoda Insecta Orthoptera Acrididae Chorthippus Chorthippus biguttulus SPECIES Chorthippus biguttulus (Linnaeus, 1758) Chorthippus biguttulus DE "NSG Chemnitzaue bei Draisdorf" Mitte "Heinersdorfer Teiche" PRESENT bb646dff-a905-4403-a49b-6d378c2cf0d9 50.881638 12.894707 250.0 2018-09-09T00:00:00 9 9 2018 1708251 1708251 HUMAN_OBSERVATION naturgucker naturgucker -449543714 CC_BY_4_0 -1182966235 2023-06-07T15:00:36.244Z >>. If the fields are not quoted (e.g. field separator does not appear within any field), try quote="" to avoid this warning.
```
