### PR TITLE
setting http2 for occ_search occ_download_wait occ_data

### DIFF
--- a/R/occ_data.R
+++ b/R/occ_data.R
@@ -109,7 +109,7 @@ occ_data <- function(taxonKey=NULL,
                     lifeStage = NULL,
                     isInCluster = NULL,
                     distanceFromCentroidInMeters = NULL,
-                    curlopts = list()) {
+                    curlopts = list(http_version=2)) {
 
   geometry <- geometry_handler(geometry, geom_big, geom_size, geom_n)
 

--- a/R/occ_download_wait.R
+++ b/R/occ_download_wait.R
@@ -25,8 +25,10 @@
 #' occ_download_wait("0000066-140928181241064") 
 #' 
 #' }
-occ_download_wait <- function(x, status_ping = 5, curlopts = list(),
-  quiet = FALSE) {
+occ_download_wait <- function(x,
+                              status_ping = 5,
+                              curlopts = list(http_version=2),
+                              quiet = FALSE) {
   
   if(!grepl("[0-9]+-[0-9]+",x)) stop("x should be a downloadkey or an occ_download object.")
   # assert(x, "occ_download")

--- a/R/occ_search.r
+++ b/R/occ_search.r
@@ -103,7 +103,7 @@ occ_search <- function(taxonKey=NULL,
                        facetMincount = NULL,
                        facetMultiselect = NULL,
                        skip_validate = TRUE,
-                       curlopts = list(), ...) {
+                       curlopts = list(http_version=2), ...) {
   
   pchk(return, "occ_search")
   geometry <- geometry_handler(geometry, geom_big, geom_size, geom_n)

--- a/man/occ_data.Rd
+++ b/man/occ_data.Rd
@@ -74,7 +74,7 @@ occ_data(
   lifeStage = NULL,
   isInCluster = NULL,
   distanceFromCentroidInMeters = NULL,
-  curlopts = list()
+  curlopts = list(http_version = 2)
 )
 }
 \arguments{

--- a/man/occ_download_wait.Rd
+++ b/man/occ_download_wait.Rd
@@ -4,7 +4,12 @@
 \alias{occ_download_wait}
 \title{Wait for an occurrence download to be done}
 \usage{
-occ_download_wait(x, status_ping = 5, curlopts = list(), quiet = FALSE)
+occ_download_wait(
+  x,
+  status_ping = 5,
+  curlopts = list(http_version = 2),
+  quiet = FALSE
+)
 }
 \arguments{
 \item{x}{and object of class \code{occ_download} or downloadkey}

--- a/man/occ_search.Rd
+++ b/man/occ_search.Rd
@@ -79,7 +79,7 @@ occ_search(
   facetMincount = NULL,
   facetMultiselect = NULL,
   skip_validate = TRUE,
-  curlopts = list(),
+  curlopts = list(http_version = 2),
   ...
 )
 }


### PR DESCRIPTION
https://github.com/ropensci/rgbif/issues/579

Setting http2 as default for

`curlopts = list(http_version=2)`


* occ_search
* occ_data
* occ_download_wait

Might do it for more functions if users complain about 

```
#> Error in curl::curl_fetch_memory(x$url$url, handle = x$url$handle) : 
#>  HTTP/2 stream 3 was not closed cleanly before end of the underlying stream
```