### PR TITLE
rgbif 3.7.8

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Description: A programmatic interface to the Web Service methods
     retrieving information on data providers, getting species occurrence
     records, getting counts of occurrence records, and using the GBIF
     tile map service to make rasters summarizing huge amounts of data.
-Version: 3.7.7.6
+Version: 3.7.8
 License: MIT + file LICENSE
 Authors@R: c(
     person("Scott", "Chamberlain", role = "aut", comment = c(ORCID="0000-0003-1444-9135")),

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/ropensci/rgbif",
   "issueTracker": "https://github.com/ropensci/rgbif/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "3.7.7",
+  "version": "3.7.8",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -115,15 +115,27 @@
     },
     {
       "@type": "SoftwareApplication",
-      "identifier": "raster",
-      "name": "raster",
+      "identifier": "terra",
+      "name": "terra",
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
         "name": "Comprehensive R Archive Network (CRAN)",
         "url": "https://cran.r-project.org"
       },
-      "sameAs": "https://CRAN.R-project.org/package=raster"
+      "sameAs": "https://CRAN.R-project.org/package=terra"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "magick",
+      "name": "magick",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=magick"
     },
     {
       "@type": "SoftwareApplication",
@@ -346,7 +358,7 @@
   "applicationCategory": "Biodiversity",
   "isPartOf": "https://ropensci.org",
   "keywords": ["GBIF", "specimens", "API", "web-services", "occurrences", "species", "taxonomy", "gbif", "api", "data", "biodiversity", "rstats", "r", "spocc", "r-package", "lifewatch", "oscibio"],
-  "fileSize": "12483.103KB",
+  "fileSize": "11313.313KB",
   "citation": [
     {
       "@type": "SoftwareSourceCode",
@@ -390,7 +402,7 @@
       ],
       "name": "rgbif: Interface to the Global Biodiversity Information Facility API",
       "url": "https://CRAN.R-project.org/package=rgbif",
-      "description": "R package version 3.7.7"
+      "description": "R package version 3.7.8"
     },
     {
       "@type": "ScholarlyArticle",

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -11,7 +11,7 @@
 
 ## Reverse dependencies
 
-* I have run R CMD check on the 15 reverse dependencies. Reverse dependency checks at <https://github.com/ropensci/rgbif/actions?query=workflow%3Arevdep>. No problems were found related to this package.
+* I have run R CMD check on the 16 reverse dependencies. Reverse dependency checks at <https://github.com/ropensci/rgbif/actions?query=workflow%3Arevdep>. No problems were found related to this package.
 
 --------
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,9 +1,9 @@
 ## Test environments
 
 * local windows, R 4.2.3
-* windows latest R 4.2.3 (GitHub Actions)
-* ubuntu 20.04, R 4.2.3 (GitHub Actions)
-* macOS latest, R 4.2.3 (GitHub Actions)
+* windows latest R 4.3.1 (GitHub Actions)
+* ubuntu 20.04, R 4.3.1 (GitHub Actions)
+* macOS latest, R 4.3.1 (GitHub Actions)
 
 ## R CMD check results
 


### PR DESCRIPTION
* **rgbif** has a new logo. (#679)

### NEW FEATURES

* `map_fetch()` now returns a base map as a `magick::magick-image`. This allows for the creation of high quality images from the GBIF maps API. (#675)
* `occ_download()` terms added to key lookup. (#661) (#589)
* `pred_default()` is an `occ_download()` pred function that allows users to easily filter out commonly unwanted occurrence records. (#611)

### MINOR IMPROVEMENTS

* Stream error fixed ("HTTP/2 stream 15 was not closed cleanly before end of the underlying stream"). Now `map_fetch()`, `occ_data()`, `occ_search()`, and `occ_download_wait()` have `curlopts = list(http_version=2)`, which fixes the error. This might need to be the default setting for the whole package. (#656) 

* `name_suggest()` now gives a warning at prevents setting the `limit` > 100, since this is the GBIF API max. (#657)

### Documentation 

New article [Creating maps from occurrences](https://docs.ropensci.org/rgbif/articles/creating_maps_from_occurrences.html), which explains how to use `map_fetch()`. 

### DEPRECATED

* `occ_issues()` is now deprecated, since it is difficult to maintain, and not widely used. (#651)
