### PR TITLE
rgbif 3.7.9

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Description: A programmatic interface to the Web Service methods
     retrieving information on data providers, getting species occurrence
     records, getting counts of occurrence records, and using the GBIF
     tile map service to make rasters summarizing huge amounts of data.
-Version: 3.7.8.2
+Version: 3.7.9
 License: MIT + file LICENSE
 Authors@R: c(
     person("Scott", "Chamberlain", role = "aut", comment = c(ORCID="0000-0003-1444-9135")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,35 @@
+rgbif 3.7.9
+===========
+
+### NEW FEATURES
+
+There have been many additions for accessing dataset metadata. 
+
+* `dataset_export()` downloads all of the results of a `dataset_search()`. 
+
+* New functions for getting dataset metadata from a datasetkey (uuid) : `dataset_get()`, `dataset_process()`, `dataset_networks()`, `dataset_constituents()`, `dataset_comment()`, `dataset_contact()`, `dataset_endpoint()`, 
+`dataset_identifier()`,  `dataset_machinetag()`, `dataset_tag()`, `dataset_metrics()`. 
+
+* New function for getting more obscure dataset metadata, such as machineTags: `dataset()`.  
+
+* New functions for listing dataset metadata : `dataset_noendpoint()`, `dataset_duplicate()`. 
+ 
+* `dataset_doi()` gets dataset metadata from the dataset's doi. 
+
+### MINOR IMPROVEMENTS
+
+* Error message improvements for `occ_count()`. (#686)
+
+### Documentation 
+
+* New article [Getting Dataset Metadata From GBIF](https://docs.ropensci.org/rgbif/articles/getting_dataset_info.html)
+
+### DEPRECATED
+
+* There are no longer static data files in rgbif. This data is better fetched fresh from the appropriate endpoints. (#690) (#688)
+
+* `datasets()` is soft deprecated, since the interface was overloaded and confusing. See functional replacements above. 
+
 rgbif 3.7.8
 ===========
 

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/ropensci/rgbif",
   "issueTracker": "https://github.com/ropensci/rgbif/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "3.7.8",
+  "version": "3.7.9",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -358,11 +358,11 @@
   "applicationCategory": "Biodiversity",
   "isPartOf": "https://ropensci.org",
   "keywords": ["GBIF", "specimens", "API", "web-services", "occurrences", "species", "taxonomy", "gbif", "api", "data", "biodiversity", "rstats", "r", "spocc", "r-package", "lifewatch", "oscibio"],
-  "fileSize": "11313.313KB",
+  "fileSize": "11587.689KB",
   "citation": [
     {
       "@type": "SoftwareSourceCode",
-      "datePublished": "2023",
+      "datePublished": "2024",
       "author": [
         {
           "@type": "Person",
@@ -402,7 +402,7 @@
       ],
       "name": "rgbif: Interface to the Global Biodiversity Information Facility API",
       "url": "https://CRAN.R-project.org/package=rgbif",
-      "description": "R package version 3.7.8"
+      "description": "R package version 3.7.9"
     },
     {
       "@type": "ScholarlyArticle",

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,9 +1,9 @@
 ## Test environments
 
 * local windows, R 4.2.3
-* windows latest R 4.3.1 (GitHub Actions)
-* ubuntu 20.04, R 4.3.1 (GitHub Actions)
-* macOS latest, R 4.3.1 (GitHub Actions)
+* windows latest R 4.3.2 (GitHub Actions)
+* ubuntu 20.04, R 4.3.2 (GitHub Actions)
+* macOS latest, R 4.3.2 (GitHub Actions)
 
 ## R CMD check results
 


### PR DESCRIPTION
### NEW FEATURES

There have been many additions for accessing dataset metadata. 

* `dataset_export()` downloads all of the results of a `dataset_search()`. 

* New functions for getting dataset metadata from a datasetkey (uuid) : `dataset_get()`, `dataset_process()`, `dataset_networks()`, `dataset_constituents()`, `dataset_comment()`, `dataset_contact()`, `dataset_endpoint()`, 
`dataset_identifier()`,  `dataset_machinetag()`, `dataset_tag()`, `dataset_metrics()`. 

* New function for getting more obscure dataset metadata, such as machineTags: `dataset()`.  

* New functions for listing dataset metadata : `dataset_noendpoint()`, `dataset_duplicate()`. 
 
* `dataset_doi()` gets dataset metadata from the dataset's doi. 

### MINOR IMPROVEMENTS

* Error message improvements for `occ_count()`. (#686)

### Documentation 

* New article [Getting Dataset Metadata From GBIF](https://docs.ropensci.org/rgbif/articles/getting_dataset_info.html)

### DEPRECATED

* There are no longer static data files in rgbif. This data is better fetched fresh from the appropriate endpoints. (#690) (#688)

* `datasets()` is soft deprecated, since the interface was overloaded and confusing. See functional replacements above. 

