### PR TITLE
v3.8.5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Description: A programmatic interface to the Web Service methods
     retrieving information on data providers, getting species occurrence
     records, getting counts of occurrence records, and using the GBIF
     tile map service to make rasters summarizing huge amounts of data.
-Version: 3.8.4.5
+Version: 3.8.5
 License: MIT + file LICENSE
 Authors@R: c(
     person("Scott", "Chamberlain", role = "aut", comment = c("0000-0003-1444-9135")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,33 @@
+rgbif 3.8.5
+===========
+
+### NEW FEATURES
+
+New functions for accessing GBIF occurrence download statistics (#837) (#823):
+
+* `occ_download_stats()` to retrieve summarized download statistics
+* `occ_download_stats_export()` to export download summaries
+* `occ_download_stats_user_country()` to get downloads by user country
+* `occ_download_stats_dataset_records()` to get downloaded records by dataset
+* `occ_download_stats_dataset()` to get downloads by dataset
+* `occ_download_stats_source()` to get downloads by source
+
+`occ_download()` now supports downloading multiple taxonomy downloads. (#830) (#832)
+`occ_download()` now supports downloading verbatim extension data. (#829) (#831)
+
+### BUG FIXES
+
+Fixed bug in `name_backbone_checklist()`. (#820) (#822)
+Fixed `name_backbone()` to include `acceptedUsageKey` and `acceptedScientificName` in output. (#824) (#826)
+
+### MINOR IMPROVEMENTS
+
+Removed `wk` package dependency and implemented internal WKT validation. (#827) (#828)
+
+### DOCUMENTATION
+
+Clarified license format in download predicates documentation. (#836)
+
 rgbif 3.8.4
 ===========
 

--- a/R/occ_data.R
+++ b/R/occ_data.R
@@ -29,7 +29,7 @@
 #' @param institutionCode An identifier of any form assigned by the source to 
 #' identify the institution the record belongs to.
 #' @param basisOfRecord (character) The specific nature of the data record. See 
-#' [here](https://gbif.github.io/parsers/apidocs/org/gbif/api/vocabulary/BasisOfRecord.html).
+#' [here](https://dwc.tdwg.org/terms/#dwc:basisOfRecord).
 #'    
 #'    \itemize{
 #'      \item "FOSSIL_SPECIMEN" 

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/ropensci/rgbif",
   "issueTracker": "https://github.com/ropensci/rgbif/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "3.8.4",
+  "version": "3.8.5",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -345,28 +345,16 @@
       "identifier": "stats",
       "name": "stats"
     },
-    "13": {
-      "@type": "SoftwareApplication",
-      "identifier": "wk",
-      "name": "wk",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
-      "sameAs": "https://CRAN.R-project.org/package=wk"
-    },
     "SystemRequirements": null
   },
   "applicationCategory": "Biodiversity",
   "isPartOf": "https://ropensci.org",
   "keywords": ["GBIF", "specimens", "API", "web-services", "occurrences", "species", "taxonomy", "gbif", "api", "data", "biodiversity", "rstats", "r", "spocc", "r-package", "lifewatch", "oscibio"],
-  "fileSize": "18911.06KB",
+  "fileSize": "19022.678KB",
   "citation": [
     {
       "@type": "SoftwareSourceCode",
-      "datePublished": "2025",
+      "datePublished": "2026",
       "author": [
         {
           "@type": "Person",
@@ -406,7 +394,7 @@
       ],
       "name": "rgbif: Interface to the Global Biodiversity Information Facility API",
       "url": "https://CRAN.R-project.org/package=rgbif",
-      "description": "R package version 3.8.4"
+      "description": "R package version 3.8.5"
     },
     {
       "@type": "ScholarlyArticle",

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -11,7 +11,7 @@
 
 ## Reverse dependencies
 
-* I have run R CMD check on the 14 reverse dependencies. Reverse dependency checks at <https://github.com/ropensci/rgbif/actions?query=workflow%3Arevdep>. No problems were found related to this package.
+* I have run R CMD check on the 15 reverse dependencies. Reverse dependency checks at <https://github.com/ropensci/rgbif/actions?query=workflow%3Arevdep>. No problems were found related to this package.
 
 --------
 

--- a/man-roxygen/occsearch.r
+++ b/man-roxygen/occsearch.r
@@ -27,7 +27,7 @@
 #' @param institutionCode An identifier of any form assigned by the source to 
 #' identify the institution the record belongs to.
 #' @param basisOfRecord (character) The specific nature of the data record. See 
-#' [here](https://gbif.github.io/parsers/apidocs/org/gbif/api/vocabulary/BasisOfRecord.html).
+#' [here](https://dwc.tdwg.org/terms/#dwc:basisOfRecord).
 #'    
 #'    \itemize{
 #'      \item "FOSSIL_SPECIMEN" 

--- a/man/occ_data.Rd
+++ b/man/occ_data.Rd
@@ -152,7 +152,7 @@ recorded the occurrence}
 provided the taxonomic identification of the occurrence.}
 
 \item{basisOfRecord}{(character) The specific nature of the data record. See
-\href{https://gbif.github.io/parsers/apidocs/org/gbif/api/vocabulary/BasisOfRecord.html}{here}.
+\href{https://dwc.tdwg.org/terms/#dwc:basisOfRecord}{here}.
 
 \itemize{
 \item "FOSSIL_SPECIMEN"

--- a/man/occ_search.Rd
+++ b/man/occ_search.Rd
@@ -214,7 +214,7 @@ recorded the occurrence}
 provided the taxonomic identification of the occurrence.}
 
 \item{basisOfRecord}{(character) The specific nature of the data record. See
-\href{https://gbif.github.io/parsers/apidocs/org/gbif/api/vocabulary/BasisOfRecord.html}{here}.
+\href{https://dwc.tdwg.org/terms/#dwc:basisOfRecord}{here}.
 
 \itemize{
 \item "FOSSIL_SPECIMEN"


### PR DESCRIPTION
rgbif 3.8.5
===========

### NEW FEATURES

New functions for accessing GBIF occurrence download statistics (#837) (#823):

* `occ_download_stats()` to retrieve summarized download statistics
* `occ_download_stats_export()` to export download summaries
* `occ_download_stats_user_country()` to get downloads by user country
* `occ_download_stats_dataset_records()` to get downloaded records by dataset
* `occ_download_stats_dataset()` to get downloads by dataset
* `occ_download_stats_source()` to get downloads by source

`occ_download()` now supports downloading multiple taxonomy downloads. (#830) (#832)
`occ_download()` now supports downloading verbatim extension data. (#829) (#831)

### BUG FIXES

Fixed bug in `name_backbone_checklist()`. (#820) (#822)
Fixed `name_backbone()` to include `acceptedUsageKey` and `acceptedScientificName` in output. (#824) (#826)

### MINOR IMPROVEMENTS

Removed `wk` package dependency and implemented internal WKT validation. (#827) (#828)

### DOCUMENTATION

Clarified license format in download predicates documentation. (#836)