### PR TITLE
fix: correct sucessfully->successfully typo in message

### DIFF
--- a/R/occ_download_cancel.R
+++ b/R/occ_download_cancel.R
@@ -42,7 +42,7 @@ occ_download_cancel <- function(key, user = NULL, pwd = NULL,
   )
   res <- cli$delete(body = FALSE)
   res$raise_for_status()
-  if (res$status_code == 204) message("Download sucessfully deleted") else res
+  if (res$status_code == 204) message("Download successfully deleted") else res
 }
 
 #' @export


### PR DESCRIPTION
Fix typo in R/occ_download_cancel.R line 45: `Download sucessfully deleted` → `Download successfully deleted` in user-visible R `message()` call.

Gate-1✅ (no existing PR for this fix) | Gate-2✅ (1 OPEN PR #854, unrelated) | Gate-3✅ (1 commit)