### PR TITLE
Fix ORCID and ROR syntax

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,15 +11,15 @@ Description: A programmatic interface to the Web Service methods
 Version: 3.8.5.12
 License: MIT + file LICENSE
 Authors@R: c(
-    person("Scott", "Chamberlain", role = "aut", comment = c("0000-0003-1444-9135")),
-    person("Damiano", "Oldoni", role = "aut", comment = c("0000-0003-3445-7562")),
-    person("Vijay", "Barve", role = "ctb", comment = c("0000-0002-4852-2567")),
-    person("Peter", "Desmet", role = "ctb", comment = c("0000-0002-8442-8025")),
+    person("Scott", "Chamberlain", role = "aut", comment = c(ORCID = "0000-0003-1444-9135")),
+    person("Damiano", "Oldoni", role = "aut", comment = c(ORCID = "0000-0003-3445-7562")),
+    person("Vijay", "Barve", role = "ctb", comment = c(ORCID = "0000-0002-4852-2567")),
+    person("Peter", "Desmet", role = "ctb", comment = c(ORCID = "0000-0002-8442-8025")),
     person("Laurens", "Geffert", role = "ctb"),
-    person("Dan", "Mcglinn", role = "ctb", comment = c("0000-0003-2359-3526")),
-    person("Karthik", "Ram", role = "ctb", comment = c("0000-0002-0233-1757")),
-    person(given = "rOpenSci", role = "fnd", comment = c("019jywm96")),
-    person("John","Waller", role = c("aut", "cre"), email = "jwaller@gbif.org", comment = c("0000-0002-7302-5976"))
+    person("Dan", "Mcglinn", role = "ctb", comment = c(ORCID = "0000-0003-2359-3526")),
+    person("Karthik", "Ram", role = "ctb", comment = c(ORCID = "0000-0002-0233-1757")),
+    person(given = "rOpenSci", role = "fnd", comment = c(ROR = "019jywm96")),
+    person("John","Waller", role = c("aut", "cre"), email = "jwaller@gbif.org", comment = c(ORCID = "0000-0002-7302-5976"))
     )
 URL: https://github.com/ropensci/rgbif (devel),
     https://docs.ropensci.org/rgbif/ (documentation)


### PR DESCRIPTION
## Description


The comment for ORCID and ROR in DESCRIPTION needs to be a **named** vector for it to be identified properly.

You can see that it currently doesn't render properly on CRAN or in the pkgdown website:

- https://cran.r-project.org/package=rgbif
- https://docs.ropensci.org/rgbif/

Example of a package where it's recognized:

- https://cran.r-project.org/package=lightr
- https://docs.ropensci.org/lightr/
