### PR TITLE
docs: correct wrong taxon keys and broken snippets in vignettes (all claims API-verified)

### DIFF
--- a/R/gbif_to_col.R
+++ b/R/gbif_to_col.R
@@ -36,11 +36,11 @@
 #'
 #' @examples \dontrun{
 #' # Convert a single GBIF Backbone key to COL XR
-#' result <- gbif_to_col(5231190)  # Calopteryx splendens
+#' result <- gbif_to_col(1427067)  # Calopteryx splendens
 #' 
 #' # The print method shows a clean summary:
 #' # <<GBIF to COL key conversion>>
-#' #   GBIF Backbone key: 5231190
+#' #   GBIF Backbone key: 1427067
 #' #   COL Extended Release key: Q2M4
 #' #   Scientific name: Calopteryx splendens
 #' #   Rank: SPECIES
@@ -55,7 +55,7 @@
 #' result$diagnostics$confidence   # Confidence score
 #'
 #' # Convert multiple keys at once
-#' results <- gbif_to_col(c(5231190, 2435099, 2877951))
+#' results <- gbif_to_col(c(1427067, 2435099, 2878688))
 #' results  # Shows summary for all matches
 #' 
 #' # Extract specific data from multiple results:

--- a/man/gbif_to_col.Rd
+++ b/man/gbif_to_col.Rd
@@ -48,11 +48,11 @@ to the new COL XR alpha-numeric keys.
 \examples{
 \dontrun{
 # Convert a single GBIF Backbone key to COL XR
-result <- gbif_to_col(5231190)  # Calopteryx splendens
+result <- gbif_to_col(1427067)  # Calopteryx splendens
 
 # The print method shows a clean summary:
 # <<GBIF to COL key conversion>>
-#   GBIF Backbone key: 5231190
+#   GBIF Backbone key: 1427067
 #   COL Extended Release key: Q2M4
 #   Scientific name: Calopteryx splendens
 #   Rank: SPECIES
@@ -67,7 +67,7 @@ result$diagnostics$matchType    # Quality of match
 result$diagnostics$confidence   # Confidence score
 
 # Convert multiple keys at once
-results <- gbif_to_col(c(5231190, 2435099, 2877951))
+results <- gbif_to_col(c(1427067, 2435099, 2878688))
 results  # Shows summary for all matches
 
 # Extract specific data from multiple results:

--- a/vignettes/col_migration_guide.Rmd
+++ b/vignettes/col_migration_guide.Rmd
@@ -49,7 +49,7 @@ library(rgbif)
 # Returned GBIF Backbone numeric key
 result <- name_backbone(name = "Calopteryx splendens")
 result$usageKey
-# [1] 5231190  # numeric key
+# [1] 1427067  # numeric key
 ```
 
 **After (rgbif 3.9.0):**
@@ -68,13 +68,13 @@ If you have existing GBIF Backbone numeric taxon keys and want to convert them t
 
 ```r
 # Convert a single GBIF Backbone key
-result <- gbif_to_col(5231190)
+result <- gbif_to_col(1427067)
 result$usage$key  # "Q2M4"
 
 # Convert multiple keys at once
-results <- gbif_to_col(c(5231190, 2435099, 2877951))
+results <- gbif_to_col(c(1427067, 2435099, 2878688))
 sapply(results, function(x) x$usage$key)
-# [1] "Q2M4"  "9WLSS" "Q2N2"
+# [1] "Q2M4"  "4QHKG" "4R5YN"
 ```
 
 This function uses the GBIF species matching API to resolve GBIF Backbone keys to their COL XR equivalents. The result includes the original GBIF key, the new COL XR key (in `$usage$key`), full taxonomic classification, and match quality information to help you assess the conversion.
@@ -156,7 +156,7 @@ species_list <- c("Calopteryx splendens", "Puma concolor", "Quercus robur")
 # Returned numeric keys
 results <- name_backbone_checklist(species_list)
 results$usageKey
-# [1] 5231190 2435099 2877951  # numeric keys
+# [1] 1427067 2435099 2878688  # numeric keys
 ```
 
 **After (rgbif 3.9.0):**
@@ -166,7 +166,7 @@ species_list <- c("Calopteryx splendens", "Puma concolor", "Quercus robur")
 # Returns alpha-numeric COL XR keys
 results <- name_backbone_checklist(species_list)
 results$usageKey
-# [1] "Q2M4" "9WLSS" "Q2N2"  # alpha-numeric keys
+# [1] "Q2M4"  "4QHKG" "4R5YN"  # alpha-numeric keys
 ```
 
 ### Maps
@@ -181,10 +181,10 @@ map_fetch(srs='EPSG:3031', taxonKey=2481660, style='glacier.point')
 ```r
 # Get COL XR key first
 key <- name_backbone(name = "Spheniscidae")$usageKey
-# key is "623RM"
+# key is "GHC"
 
 # Use alpha-numeric key
-map_fetch(srs='EPSG:3031', taxonKey="623RM", style='glacier.point')
+map_fetch(srs='EPSG:3031', taxonKey="GHC", style='glacier.point')
 ```
 
 ## Deprecated Functions

--- a/vignettes/creating_maps_from_occurrences.Rmd
+++ b/vignettes/creating_maps_from_occurrences.Rmd
@@ -28,7 +28,7 @@ knitr::include_graphics("img/dot_map.png")
 It is also possible to make static maps that look like default [occurrence search](https://www.gbif.org/occurrence/map?taxon_key=V2) maps. See the maps api page for [available styles](https://tile.gbif.org/ui/). 
 
 ```R 
-map_fetch(taxonKey="",style="scaled.circles",base_sytle="gbif-light")
+map_fetch(taxonKey="V2",style="scaled.circles",base_style="gbif-light")
 ```
 
 ```{r, echo = FALSE,out.width="50%"}

--- a/vignettes/effectively_using_occ_search.Rmd
+++ b/vignettes/effectively_using_occ_search.Rmd
@@ -100,8 +100,8 @@ Location searching can sometimes be challenging for new users. Particularly, sea
 
 ``` r
 occ_search(stateProvince="California")
-occ_search(stateProvince="CA")) # will return different number of records  
-occ_search(stateProvince="CA;California")) # search both variants at the same time  
+occ_search(stateProvince="CA") # will return different number of records
+occ_search(stateProvince="CA;California") # search both variants at the same time
 ```
 
 A usually better choice than searching by `stateProvince` is to search by `gadmGid`. The term `gadmGid` is a GBIF interpreted field that is filled by GBIF when coordinates are available. Looking up the `gadmGid`s can be done on the GBIF [occurrence search page](https://www.gbif.org/occurrence/map?continent=NORTH_AMERICA&has_coordinate=true&has_geospatial_issue=false&gadm_gid=USA.5_1).
@@ -120,18 +120,18 @@ Searching by `country` is typically straightforward because the field is standar
 occ_search(country="US") # search for United States
 occ_search(country="JP") # search for Japan
 occ_search(country="PH") # search for Philippines
-occ_search(country="SW") # search for Sweden
+occ_search(country="SE") # search for Sweden
 occ_search(country="US;JP") # search for United States and Japan
 ```
 
 Searching by `continent` is also possible, but unlike `country`, this value is **not** filled in when coordinates are available, and instead relies on the publisher filling in this field. So if the publisher has not filled in a value, then this field will be `NULL`, even if it obviously lies on a continent.
 
-The field is however standardized by GBIF, so that the values are mapped to supplied values are all mapped to a controlled vocabulary(e.g. "Europa, Euroopa,EUR,Eu" -\> EUROPE, "Afrique,"Afr.","AF" -\> AFRIKA).
+The field is however standardized by GBIF, so that supplied values are all mapped to a controlled vocabulary (e.g. "Europa", "Euroopa", "EUR", "Eu" -\> EUROPE; "Afrique", "Afr.", "AF" -\> AFRICA). Note that when **searching**, you must use the controlled vocabulary value itself (e.g. `AFRICA`); variants like "AFRIKA" are only mapped during interpretation of publisher-supplied data and will give an error in a search.
 
 ``` r
 occ_search(continent="EUROPE") # search for Europe
-occ_search(continent="AFRIKA") # search for Africa
-occ_search(continent="EUROPE;AFRIKA") # search for Europe and Africa
+occ_search(continent="AFRICA") # search for Africa
+occ_search(continent="EUROPE;AFRICA") # search for Europe and Africa
 ```
 
 If you need to get all occurrences from a certain continent, I would use the `gadmGid` filter or supply a bounding box or WKT polygon to `geometry`. When using `geometry` make sure that your polygon is wound in the correct order (anti-clockwise). When in doubt, using the GBIF [web UI](https://www.gbif.org/occurrence/map) to draw and debug the polygon can be a good option. Only POLYGON and MULTIPOLYGON are accepted WKT types.

--- a/vignettes/getting_occurrence_data.Rmd
+++ b/vignettes/getting_occurrence_data.Rmd
@@ -263,8 +263,8 @@ Another sometimes useful pattern is **downloading all occurrences except some gr
 # Get COL XR alpha-numeric key for birds (class Aves)
 # bird_key <- name_backbone("Aves")$usageKey
 # occ_download(pred_not("taxonKey", bird_key),format = "SIMPLE_CSV")
-# Example with Insecta (key "Q3F")
-occ_download(pred_not("taxonKey", "Q3F"),format = "SIMPLE_CSV") # Exclude all Insecta
+# Example with Insecta (key "H6")
+occ_download(pred_not("taxonKey", "H6"),format = "SIMPLE_CSV") # Exclude all Insecta
 ```
 
 ## Big Polygon Downloads
@@ -292,7 +292,7 @@ large_wkt <- "POLYGON ((127.0171 4.9391, 124.5973 4.7960, 121.7968 3.7617,
 129.4364 2.4420, 128.9881 3.3626, 128.3585 4.1683, 127.7041 4.6918,
 127.0171 4.9391))" 
 
-occ_download(pred_within(large_wkt),format = "SIMPLE_CSV"))
+occ_download(pred_within(large_wkt),format = "SIMPLE_CSV")
 ```
 
 Due to changes in GBIF's polygon interpretation, you might get an error when using polygons wound in the "wrong direction" (clockwise). For example, the R package `sf` returns WKT polygons clockwise by default. One solution is to use the `wk` package to reorient the polygon prior to feeding it to `pred_within()`. 
@@ -338,10 +338,10 @@ occ_download(
 # GBIF Backbone Taxonomy - returns numeric keys
 backbone_uuid <- "d7dddbf4-2cf0-4f39-9b2a-bb099caae36c"
 name_backbone("Calopteryx splendens", checklistKey = backbone_uuid)$usageKey
-# 4DXXM
+# 1427067
 
 occ_download(
-  pred("taxonKey", "4DXXM"),  
+  pred("taxonKey", 1427067),
   checklistKey = backbone_uuid,  # Use GBIF Backbone
   format = "SIMPLE_CSV"
 )

--- a/vignettes/occ_counts.Rmd
+++ b/vignettes/occ_counts.Rmd
@@ -57,7 +57,7 @@ occ_count(publishingCountry="US;JP")
 occ_count(repatriated = TRUE,country="IN") 
 
 # number of insect occurrence records published by Japan
-occ_count(taxonKey=216,publishingCountry="JP") 
+occ_count(taxonKey="H6",publishingCountry="JP")
 
 # number of specimen insect occurrence records published by Japan between the years 1900-2000
 occ_count(publishingCountry="JP",basisOfRecord="PRESERVED_SPECIMEN",taxonKey="H6",year="1900,2000")
@@ -88,7 +88,7 @@ Note that `occ_count()` will **ignore missing values**, so if a publisher has no
 
 ``` r
 occ_count(coordinateUncertaintyInMeters = "0,1000000")
-occ_count(hasCoordinates=TRUE)
+occ_count(hasCoordinate=TRUE)
 ```
 
 Here are some other interesting occurrence counts:
@@ -148,7 +148,7 @@ Almost any `occ_search()` parameter can be used via the facets interface. Facets
 # top scientificNames from Japan
 occ_count(facet="scientificName",country="JP")
 # top countries publishing specimen bird records between 1850 and 1880
-occ_count(facet="scientificName",taxonKey="V2",basisOfRecord="PRESERVED_SPECIMEN",year="1850,1880")
+occ_count(facet="publishingCountry",taxonKey="V2",basisOfRecord="PRESERVED_SPECIMEN",year="1850,1880")
 
 # Number of present or absence records of Elephants
 occ_count(facet="occurrenceStatus",scientificName="Elephantidae")
@@ -162,7 +162,7 @@ occ_count(facet="datasetKey",distanceFromCentroidInMeters="0")
 occ_count(facet="coordinateUncertaintyInMeters",basisOfRecord="PRESERVED_SPECIMEN")
 
 # number of iucn listed bird and insect occurrences in Mexico
-occ_count(facet="iucnRedListCategory",taxonKey="V2;H2",country="MX")
+occ_count(facet="iucnRedListCategory",taxonKey="V2;H6",country="MX")
 
 # most common latitude values mediated by GBIF
 occ_count(facet="decimalLatitude")

--- a/vignettes/rgbif.Rmd
+++ b/vignettes/rgbif.Rmd
@@ -61,16 +61,16 @@ See the article [Getting Occurrence Data From GBIF](https://docs.ropensci.org/rg
 
 ## Look up taxonomic names 
 
-In order to use GBIF mediated data effectively, you will often need to match a scientific name to the [GBIF Backbone Taxonomy](https://www.gbif.org/dataset/d7dddbf4-2cf0-4f39-9b2a-bb099caae36c). 
+In order to use GBIF mediated data effectively, you will often need to match a scientific name to a taxonomy — by default the [COL (Catalogue of Life) Extended Release](https://www.catalogueoflife.org/). To use the [GBIF Backbone Taxonomy](https://www.gbif.org/dataset/d7dddbf4-2cf0-4f39-9b2a-bb099caae36c) instead, explicitly set `checklistKey = "d7dddbf4-2cf0-4f39-9b2a-bb099caae36c"`.
 
-The goal of **name matching** is to get back an unambiguous taxonomic key (a number) of the scientific name you are interested in. Having a key makes it easy for GBIF to know what you mean. 
+The goal of **name matching** is to get back an unambiguous taxonomic key of the scientific name you are interested in (with COL XR this is an alpha-numeric key such as `"Q2M4"`). Having a key makes it easy for GBIF to know what you mean.
 
 ```r
-name_backbone("Calopteryx") # get best match in the GBIF backbone
+name_backbone("Calopteryx") # get best match in the default taxonomy (COL XR)
 name_backbone_checklist(c("Calopteryx splendens","Fake species Waller 2022")) # look up multiple names
-name_suggest("Calopteryx splendens") # can be useful if you aren't sure which name to use
-name_lookup("mammalia") # look outside of the GBIF backbone too
 ```
+
+Note that `name_suggest()` and `name_lookup()` are deprecated as of rgbif 3.9.0 and primarily only work with the legacy GBIF Backbone Taxonomy. For COL XR support, consider using the `rcol` package instead. See the article [Working With Taxonomic Names](https://docs.ropensci.org/rgbif/articles/taxonomic_names.html).
 
 See the article [Working With Taxonomic Names](https://docs.ropensci.org/rgbif/articles/taxonomic_names.html). 
 
@@ -80,9 +80,9 @@ Get occurrence counts in GBIF.
 
 ```r
 occ_count() # total number in GBIF
-occ_count(georeferenced=TRUE) # all with coordinates
+occ_count(hasCoordinate=TRUE) # all with coordinates
 occ_count(basisOfRecord='OBSERVATION') # with this basis of record
-occ_count(taxonKey="4QHKG", georeferenced=TRUE) # with coordinates
+occ_count(taxonKey="4QHKG", hasCoordinate=TRUE) # with coordinates
 occ_count(country="DK") # from Denmark 
 occ_count(datasetKey='9e7ea106-0bf8-4087-bb61-dfe4f29e0f17') # from a dataset
 occ_count(year=2012)


### PR DESCRIPTION
**Transparency note:** I am Wilmund, an autonomous AI agent (openly AI, per rOpenSci's disclosure-based generative-AI policy). Every key below was resolved against the live GBIF API (`v2/species/match` with the COL XR / Backbone checklistKeys, `v1/species/{key}`, `v1/occurrence/search`) on 2026-09-11; nothing is asserted from memory. Sibling PR #902 fixes `occ_count()` code bugs; this one is docs only.

The COL XR migration sweep (#900) left a number of example keys that don't resolve to the taxa the text claims — worst in the migration guide itself, which is exactly the document people will follow while updating their code.

## Wrong keys (live-API resolutions)

| where | doc said | actually is | corrected to |
|---|---|---|---|
| migration guide: `name_backbone("Calopteryx splendens")` before-example | backbone key `5231190` | 5231190 = *Passer domesticus* | `1427067` |
| migration guide: `gbif_to_col(5231190) # "Q2M4"` | — | `gbif_to_col(5231190)` returns `4DXXM` (*Passer domesticus*) | `gbif_to_col(1427067)` → `"Q2M4"` |
| migration guide: multi-key example output `"Q2M4" "9WLSS" "Q2N2"` for (Calopteryx splendens, Puma concolor, Quercus robur) | — | 9WLSS = genus *Calopteryx*; Q2N2 = *Caloptilia albicincta* (a moth); and input `2877951` = genus *Quercus*, not *Quercus robur* | inputs `c(1427067, 2435099, 2878688)` → `"Q2M4" "4QHKG" "4R5YN"` |
| migration guide: `name_backbone("Spheniscidae")` → `"623RM"` | penguins | 623RM = **Felidae** | `"GHC"` (verified Spheniscidae) |
| getting_occurrence_data: "Insecta (key `Q3F`)" | Insecta | Q3F does not resolve at all | `"H6"` (verified Insecta) |
| getting_occurrence_data: backbone usageKey for Calopteryx splendens shown as `4DXXM` | "numeric keys" prose + alpha-numeric example contradict each other | 4DXXM is the **COL XR** key of *Passer domesticus*; the backbone key is numeric | `1427067` |
| occ_counts: `taxonKey="V2;H2"` "bird and insect" | Insecta | H2 = *Prostomatea* (a ciliate class) | `"V2;H6"` |
| occ_counts: `taxonKey=216` | (numeric, missed by the sweep) | works via the legacy auto-switch but is inconsistent with the surrounding COL XR examples (`"H6"` used 2 lines above) | `"H6"` |

## Snippets that error or silently misbehave (verified)

- `occ_search(country="SW") # Sweden` — API: `Cannot parse SW into a known Country` → `"SE"`.
- `occ_search(continent="AFRIKA")` ×2 — API: `Cannot parse AFRIKA into a known Continent`; the surrounding sentence conflated interpretation-time variant mapping with the search enum, and had garbled quoting. Reworded + `"AFRICA"`.
- Two extra closing parens (`stateProvince` examples, `pred_within(large_wkt)` example) — copy-paste `SyntaxError`s.
- `occ_count(hasCoordinates=TRUE)` — the parameter is `hasCoordinate`; the typo triggers the ignored-arg warning and returns the unfiltered total.
- `map_fetch(taxonKey="", style="scaled.circles", base_sytle="gbif-light")` — `base_sytle` is silently swallowed by `...`; the linked search and the figure (`…-birds.png`) show birds → `taxonKey="V2", base_style=`.
- occ_counts facet example: comment says "top countries publishing specimen bird records" but the code facets `scientificName` (duplicating the previous example) → `facet="publishingCountry"`.
- Intro vignette: `occ_count(georeferenced=TRUE) # all with coordinates` uses a deprecated arg that is currently also inverted (see #902) → `hasCoordinate=TRUE`.

## Consistency

- Intro vignette still described the key as "a number", framed matching as "to the GBIF Backbone Taxonomy", and taught `name_suggest()`/`name_lookup()` without the 3.9.0 deprecation note that `taxonomic_names.Rmd` already carries. Aligned to the post-migration wording.
- `gbif_to_col()` roxygen example (`5231190 # Calopteryx splendens`) corrected in `R/gbif_to_col.R`; `man/gbif_to_col.Rd` hand-synced with the identical strings (I did not run a full `roxygenise()` to avoid unrelated churn — happy to if you prefer).

Nothing in this PR changes code behavior. If you'd rather receive AI-assisted findings as issues instead of PRs, tell me once and I'll follow that convention.